### PR TITLE
conditionalize `extend-mapped-file` for munmap/mmap rather than mremap on Darwin

### DIFF
--- a/ve-index.lisp
+++ b/ve-index.lisp
@@ -30,7 +30,7 @@
   (and (= (ve-key-type-id key1) (ve-key-type-id key2))
        (equalp (ve-key-id key1) (ve-key-id key2))))
 
-(defgeneric ve-key-equal (x y &optional offset1 offset1)
+(defgeneric ve-key-equal (x y &optional offset1 offset2)
   (:method ((key1 ve-key) (key2 ve-key) &optional _a _b)
     (declare (ignore _a _b))
     (%ve-key-equal key1 key2))

--- a/vev-index.lisp
+++ b/vev-index.lisp
@@ -38,7 +38,7 @@
        (equalp (vev-key-out-id key1) (vev-key-out-id key2))
        (equalp (vev-key-in-id key1) (vev-key-in-id key2))))
 
-(defgeneric vev-key-equal (x y &optional offset1 offset1)
+(defgeneric vev-key-equal (x y &optional offset1 offset2)
   (:method ((key1 vev-key) (key2 vev-key) &optional _a _b)
     (declare (ignore _a _b))
     (%vev-key-equal key1 key2))


### PR DESCRIPTION
Compiles cleanly under SBCL 2.0.7 Darwin kernel 18.7.0 and passes `tests.lisp`